### PR TITLE
移动端截图：去掉“打开APP”按钮、允许强制换行

### DIFF
--- a/src/plugins/haruka_bot/utils/browser.py
+++ b/src/plugins/haruka_bot/utils/browser.py
@@ -46,10 +46,13 @@ async def get_dynamic_screenshot(url):
             '<div class="dyn-header__right"><div data-pos="follow" class="dyn-header__following"><span class="dyn-header__following__icon"></span><span class="dyn-header__following__text">关注</span></div></div>',
             "",
         )  # 去掉关注按钮
+
         content = content.replace(
             '<div class="dyn-card">',
-            '<div class="dyn-card" style="font-family: sans-serif;">',
-        )  # 字体问题：.dyn-class里font-family是PingFangSC-Regular，使用行内CSS覆盖掉它
+            '<div class="dyn-card" style="font-family: sans-serif; overflow-wrap: break-word;">',
+        )
+        # 1. 字体问题：.dyn-class里font-family是PingFangSC-Regular，使用行内CSS覆盖掉它
+        # 2. 换行问题：遇到太长的内容（长单词、某些长链接等）允许强制换行，防止溢出
         content = content.replace(
             '<div class="launch-app-btn dynamic-float-openapp"><div class="m-dynamic-float-openapp"><span>打开APP，查看更多精彩内容</span></div> <!----></div>',
             "",

--- a/src/plugins/haruka_bot/utils/browser.py
+++ b/src/plugins/haruka_bot/utils/browser.py
@@ -50,6 +50,10 @@ async def get_dynamic_screenshot(url):
             '<div class="dyn-card">',
             '<div class="dyn-card" style="font-family: sans-serif;">',
         )  # 字体问题：.dyn-class里font-family是PingFangSC-Regular，使用行内CSS覆盖掉它
+        content = content.replace(
+            '<div class="launch-app-btn dynamic-float-openapp"><div class="m-dynamic-float-openapp"><span>打开APP，查看更多精彩内容</span></div> <!----></div>',
+            "",
+        )  # 去掉打开APP的按钮，防止遮挡较长的动态
         await page.set_content(content)
         card = await page.query_selector(".dyn-card")
         assert card


### PR DESCRIPTION
防止遮挡较长的动态