### PR TITLE
使用Arg代替T_State

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm
+.idea/

--- a/src/plugins/haruka_bot/config.py
+++ b/src/plugins/haruka_bot/config.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from pydantic import BaseSettings
 
 

--- a/src/plugins/haruka_bot/plugins/__init__.py
+++ b/src/plugins/haruka_bot/plugins/__init__.py
@@ -1,13 +1,11 @@
 from . import (  # noqa: F401
     at,
+    auto_agree,
+    auto_delete,
     dynamic,
+    help,
     live,
     permission,
     pusher,
     sub,
-    auto_agree,
-    auto_delete,
-    help,
 )
-
-# TODO 将仅群可用指令的私聊拒绝部分分离成一个独立的handle

--- a/src/plugins/haruka_bot/plugins/at/__init__.py
+++ b/src/plugins/haruka_bot/plugins/at/__init__.py
@@ -1,1 +1,1 @@
-from . import at_on, at_off  # noqa: F401
+from . import at_off, at_on  # noqa: F401

--- a/src/plugins/haruka_bot/plugins/at/at_off.py
+++ b/src/plugins/haruka_bot/plugins/at/at_off.py
@@ -17,7 +17,7 @@ at_off.__doc__ = """关闭全体 UID"""
 
 at_off.handle()(handle_uid)
 
-at_off.got("uid", prompt="请输入要关注的UID")(uid_check)
+at_off.got("uid", prompt="请输入要关闭全体的UID")(uid_check)
 
 
 @at_off.handle()

--- a/src/plugins/haruka_bot/plugins/at/at_off.py
+++ b/src/plugins/haruka_bot/plugins/at/at_off.py
@@ -4,11 +4,11 @@ from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageEvent
 from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
 from nonebot.permission import SUPERUSER
-from nonebot.typing import T_State
+from nonebot.params import ArgPlainText
 
 from ... import config
 from ...database import DB as db
-from ...utils import handle_uid, to_me
+from ...utils import handle_uid, to_me, uid_check
 
 at_off = on_command(
     "关闭全体", rule=to_me(), permission=GROUP_OWNER | GROUP_ADMIN | SUPERUSER, priority=5
@@ -17,21 +17,23 @@ at_off.__doc__ = """关闭全体 UID"""
 
 at_off.handle()(handle_uid)
 
+at_off.got("uid", prompt="请输入要关注的UID")(uid_check)
 
-@at_off.got("uid", prompt="请输入要关闭全体的UID")
-async def _(event: Union[PrivateMessageEvent, GroupMessageEvent], state: T_State):
+
+@at_off.handle()
+async def _(event: Union[PrivateMessageEvent, GroupMessageEvent], uid: str = ArgPlainText("uid")):
     """根据 UID 关闭全体"""
 
     if isinstance(event, PrivateMessageEvent):
         await at_off.finish("只有群里才能关闭全体")
         return  # IDE 快乐行
     if await db.set_sub(
-        "at", False, uid=state["uid"], type="group", type_id=event.group_id
+        "at", False, uid=uid, type="group", type_id=event.group_id
     ):
-        user = await db.get_user(uid=state["uid"])
+        user = await db.get_user(uid=uid)
         assert user is not None
         await at_off.finish(
             f"已关闭 {user.name}（{user.uid}）"
             f"{'直播推送' if not config.haruka_dynamic_at else ''}的@全体"
         )
-    await at_off.finish(f"UID（{state['uid']}）未关注，请先关注后再操作")
+    await at_off.finish(f"UID（{uid}）未关注，请先关注后再操作")

--- a/src/plugins/haruka_bot/plugins/at/at_off.py
+++ b/src/plugins/haruka_bot/plugins/at/at_off.py
@@ -3,8 +3,8 @@ from typing import Union
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageEvent
 from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
-from nonebot.permission import SUPERUSER
 from nonebot.params import ArgPlainText
+from nonebot.permission import SUPERUSER
 
 from ... import config
 from ...database import DB as db
@@ -21,15 +21,15 @@ at_off.got("uid", prompt="请输入要关闭全体的UID")(uid_check)
 
 
 @at_off.handle()
-async def _(event: Union[PrivateMessageEvent, GroupMessageEvent], uid: str = ArgPlainText("uid")):
+async def _(
+    event: Union[PrivateMessageEvent, GroupMessageEvent], uid: str = ArgPlainText("uid")
+):
     """根据 UID 关闭全体"""
 
     if isinstance(event, PrivateMessageEvent):
         await at_off.finish("只有群里才能关闭全体")
         return  # IDE 快乐行
-    if await db.set_sub(
-        "at", False, uid=uid, type="group", type_id=event.group_id
-    ):
+    if await db.set_sub("at", False, uid=uid, type="group", type_id=event.group_id):
         user = await db.get_user(uid=uid)
         assert user is not None
         await at_off.finish(

--- a/src/plugins/haruka_bot/plugins/at/at_on.py
+++ b/src/plugins/haruka_bot/plugins/at/at_on.py
@@ -3,8 +3,8 @@ from typing import Union
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageEvent
 from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
-from nonebot.permission import SUPERUSER
 from nonebot.params import ArgPlainText
+from nonebot.permission import SUPERUSER
 
 from ... import config
 from ...database import DB as db
@@ -24,15 +24,15 @@ at_on.got("uid", prompt="请输入要开启全体的UID")(uid_check)
 
 
 @at_on.handle()
-async def _(event: Union[PrivateMessageEvent, GroupMessageEvent], uid: str = ArgPlainText("uid")):
+async def _(
+    event: Union[PrivateMessageEvent, GroupMessageEvent], uid: str = ArgPlainText("uid")
+):
     """根据 UID 开启全体"""
 
     if isinstance(event, PrivateMessageEvent):
         await at_on.finish("只有群里才能开启全体")
         return  # IDE 快乐行
-    if await db.set_sub(
-        "at", True, uid=uid, type="group", type_id=event.group_id
-    ):
+    if await db.set_sub("at", True, uid=uid, type="group", type_id=event.group_id):
         user = await db.get_user(uid=uid)
         assert user is not None
         await at_on.finish(

--- a/src/plugins/haruka_bot/plugins/at/at_on.py
+++ b/src/plugins/haruka_bot/plugins/at/at_on.py
@@ -20,7 +20,7 @@ at_on.__doc__ = """开启全体 UID"""
 
 at_on.handle()(handle_uid)
 
-at_on.got("uid", prompt="请输入要关注的UID")(uid_check)
+at_on.got("uid", prompt="请输入要开启全体的UID")(uid_check)
 
 
 @at_on.handle()

--- a/src/plugins/haruka_bot/plugins/auto_agree.py
+++ b/src/plugins/haruka_bot/plugins/auto_agree.py
@@ -1,7 +1,6 @@
 from nonebot import on_request
 from nonebot.adapters.onebot.v11 import Bot, FriendRequestEvent, GroupRequestEvent
 
-
 friend_req = on_request(priority=5)
 
 
@@ -17,4 +16,6 @@ group_invite = on_request(priority=5)
 @group_invite.handle()
 async def group_agree(bot: Bot, event: GroupRequestEvent):
     if event.sub_type == "invite" and str(event.user_id) in bot.config.superusers:
-        await bot.set_group_add_request(flag=event.flag, sub_type="invite", approve=True)
+        await bot.set_group_add_request(
+            flag=event.flag, sub_type="invite", approve=True
+        )

--- a/src/plugins/haruka_bot/plugins/auto_delete.py
+++ b/src/plugins/haruka_bot/plugins/auto_delete.py
@@ -3,7 +3,6 @@ from nonebot.adapters.onebot.v11 import GroupDecreaseNoticeEvent
 
 from ..database import DB as db
 
-
 group_decrease = on_notice(priority=5)
 
 

--- a/src/plugins/haruka_bot/plugins/dynamic/dynamic_off.py
+++ b/src/plugins/haruka_bot/plugins/dynamic/dynamic_off.py
@@ -18,7 +18,6 @@ dynamic_off.got("uid", prompt="请输入要关闭动态的UID")(uid_check)
 @dynamic_off.handle()
 async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 关闭动态"""
-
     if await db.set_sub(
         "dynamic",
         False,

--- a/src/plugins/haruka_bot/plugins/dynamic/dynamic_off.py
+++ b/src/plugins/haruka_bot/plugins/dynamic/dynamic_off.py
@@ -12,7 +12,7 @@ dynamic_off.handle()(permission_check)
 
 dynamic_off.handle()(handle_uid)
 
-dynamic_off.got("uid", prompt="请输入要关注的UID")(uid_check)
+dynamic_off.got("uid", prompt="请输入要关闭动态的UID")(uid_check)
 
 
 @dynamic_off.handle()

--- a/src/plugins/haruka_bot/plugins/dynamic/dynamic_off.py
+++ b/src/plugins/haruka_bot/plugins/dynamic/dynamic_off.py
@@ -1,9 +1,9 @@
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import MessageEvent
-from nonebot.typing import T_State
+from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, handle_uid, permission_check, to_me
+from ...utils import get_type_id, handle_uid, permission_check, to_me, uid_check
 
 dynamic_off = on_command("关闭动态", rule=to_me(), priority=5)
 dynamic_off.__doc__ = """关闭动态 UID"""
@@ -12,19 +12,21 @@ dynamic_off.handle()(permission_check)
 
 dynamic_off.handle()(handle_uid)
 
+dynamic_off.got("uid", prompt="请输入要关注的UID")(uid_check)
 
-@dynamic_off.got("uid", prompt="请输入要关闭动态的UID")
-async def _(event: MessageEvent, state: T_State):
+
+@dynamic_off.handle()
+async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 关闭动态"""
 
     if await db.set_sub(
         "dynamic",
         False,
-        uid=state["uid"],
+        uid=uid,
         type=event.message_type,
         type_id=get_type_id(event),
     ):
-        user = await db.get_user(uid=state["uid"])
+        user = await db.get_user(uid=uid)
         assert user is not None
         await dynamic_off.finish(f"已关闭 {user.name}（{user.uid}）的动态推送")
-    await dynamic_off.finish(f"UID（{state['uid']}）未关注，请先关注后再操作")
+    await dynamic_off.finish(f"UID（{uid}）未关注，请先关注后再操作")

--- a/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
+++ b/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
@@ -18,7 +18,6 @@ dynamic_on.got("uid", prompt="请输入要开启动态的UID")(uid_check)
 @dynamic_on.handle()
 async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 开启动态"""
-
     if await db.set_sub(
         "dynamic",
         True,

--- a/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
+++ b/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
@@ -13,7 +13,7 @@ dynamic_on.handle()(permission_check)
 
 dynamic_on.handle()(handle_uid)
 
-dynamic_on.got("uid", prompt="请输入要关注的UID")(uid_check)
+dynamic_on.got("uid", prompt="请输入要开启动态的UID")(uid_check)
 
 
 @dynamic_on.handle()

--- a/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
+++ b/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
@@ -3,8 +3,7 @@ from nonebot.adapters.onebot.v11.event import MessageEvent
 from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
-
+from ...utils import get_type_id, handle_uid, permission_check, to_me, uid_check
 
 dynamic_on = on_command("开启动态", rule=to_me(), priority=5)
 dynamic_on.__doc__ = """开启动态 UID"""

--- a/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
+++ b/src/plugins/haruka_bot/plugins/dynamic/dynamic_on.py
@@ -1,9 +1,9 @@
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import MessageEvent
-from nonebot.typing import T_State
+from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid
+from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
 
 
 dynamic_on = on_command("开启动态", rule=to_me(), priority=5)
@@ -13,19 +13,21 @@ dynamic_on.handle()(permission_check)
 
 dynamic_on.handle()(handle_uid)
 
+dynamic_on.got("uid", prompt="请输入要关注的UID")(uid_check)
 
-@dynamic_on.got("uid", prompt="请输入要开启动态的UID")
-async def _(event: MessageEvent, state: T_State):
+
+@dynamic_on.handle()
+async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 开启动态"""
 
     if await db.set_sub(
         "dynamic",
         True,
-        uid=state["uid"],
+        uid=uid,
         type=event.message_type,
         type_id=get_type_id(event),
     ):
-        user = await db.get_user(uid=state["uid"])
+        user = await db.get_user(uid=uid)
         assert user is not None
         await dynamic_on.finish(f"已开启 {user.name}（{user.uid}）的动态推送")
-    await dynamic_on.finish(f"UID（{state['uid']}）未关注，请先关注后再操作")
+    await dynamic_on.finish(f"UID（{uid}）未关注，请先关注后再操作")

--- a/src/plugins/haruka_bot/plugins/help.py
+++ b/src/plugins/haruka_bot/plugins/help.py
@@ -4,7 +4,6 @@ from nonebot.matcher import matchers
 from ..utils import to_me
 from ..version import __version__
 
-
 help = on_command("帮助", rule=to_me(), priority=5)
 
 

--- a/src/plugins/haruka_bot/plugins/live/live_off.py
+++ b/src/plugins/haruka_bot/plugins/live/live_off.py
@@ -13,7 +13,7 @@ live_off.handle()(permission_check)
 
 live_off.handle()(handle_uid)
 
-live_off.got("uid", prompt="请输入要关注的UID")(uid_check)
+live_off.got("uid", prompt="请输入要关闭直播的UID")(uid_check)
 
 
 @live_off.handle()

--- a/src/plugins/haruka_bot/plugins/live/live_off.py
+++ b/src/plugins/haruka_bot/plugins/live/live_off.py
@@ -3,8 +3,7 @@ from nonebot.adapters.onebot.v11.event import MessageEvent
 from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
-
+from ...utils import get_type_id, handle_uid, permission_check, to_me, uid_check
 
 live_off = on_command("关闭直播", rule=to_me(), priority=5)
 live_off.__doc__ = """关闭直播 UID"""

--- a/src/plugins/haruka_bot/plugins/live/live_off.py
+++ b/src/plugins/haruka_bot/plugins/live/live_off.py
@@ -1,9 +1,9 @@
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import MessageEvent
-from nonebot.typing import T_State
+from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid
+from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
 
 
 live_off = on_command("关闭直播", rule=to_me(), priority=5)
@@ -13,19 +13,21 @@ live_off.handle()(permission_check)
 
 live_off.handle()(handle_uid)
 
+live_off.got("uid", prompt="请输入要关注的UID")(uid_check)
 
-@live_off.got("uid", prompt="请输入要关闭直播的UID")
-async def _(event: MessageEvent, state: T_State):
+
+@live_off.handle()
+async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 关闭直播"""
 
     if await db.set_sub(
         "live",
         False,
-        uid=state["uid"],
+        uid=uid,
         type=event.message_type,
         type_id=get_type_id(event),
     ):
-        user = await db.get_user(uid=state["uid"])
+        user = await db.get_user(uid=uid)
         assert user is not None
         await live_off.finish(f"已关闭 {user.name}（{user.uid}）的直播推送")
-    await live_off.finish(f"UID（{state['uid']}）未关注，请先关注后再操作")
+    await live_off.finish(f"UID（{uid}）未关注，请先关注后再操作")

--- a/src/plugins/haruka_bot/plugins/live/live_off.py
+++ b/src/plugins/haruka_bot/plugins/live/live_off.py
@@ -18,7 +18,6 @@ live_off.got("uid", prompt="请输入要关闭直播的UID")(uid_check)
 @live_off.handle()
 async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 关闭直播"""
-
     if await db.set_sub(
         "live",
         False,

--- a/src/plugins/haruka_bot/plugins/live/live_on.py
+++ b/src/plugins/haruka_bot/plugins/live/live_on.py
@@ -18,7 +18,6 @@ live_on.got("uid", prompt="请输入要开启直播的UID")(uid_check)
 @live_on.handle()
 async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 开启直播"""
-
     if await db.set_sub(
         "live",
         True,

--- a/src/plugins/haruka_bot/plugins/live/live_on.py
+++ b/src/plugins/haruka_bot/plugins/live/live_on.py
@@ -1,9 +1,9 @@
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import MessageEvent
-from nonebot.typing import T_State
+from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid
+from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
 
 
 live_on = on_command("开启直播", rule=to_me(), priority=5)
@@ -13,19 +13,21 @@ live_on.handle()(permission_check)
 
 live_on.handle()(handle_uid)
 
+live_on.got("uid", prompt="请输入要关注的UID")(uid_check)
 
-@live_on.got("uid", prompt="请输入要开启直播的UID")
-async def _(event: MessageEvent, state: T_State):
+
+@live_on.handle()
+async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 开启直播"""
 
     if await db.set_sub(
         "live",
         True,
-        uid=state["uid"],
+        uid=uid,
         type=event.message_type,
         type_id=get_type_id(event),
     ):
-        user = await db.get_user(uid=state["uid"])
+        user = await db.get_user(uid=uid)
         assert user is not None
         await live_on.finish(f"已开启 {user.name}（{user.uid}）的直播推送")
-    await live_on.finish(f"UID（{state['uid']}）未关注，请先关注后再操作")
+    await live_on.finish(f"UID（{uid}）未关注，请先关注后再操作")

--- a/src/plugins/haruka_bot/plugins/live/live_on.py
+++ b/src/plugins/haruka_bot/plugins/live/live_on.py
@@ -3,8 +3,7 @@ from nonebot.adapters.onebot.v11.event import MessageEvent
 from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
-
+from ...utils import get_type_id, handle_uid, permission_check, to_me, uid_check
 
 live_on = on_command("开启直播", rule=to_me(), priority=5)
 live_on.__doc__ = """开启直播 UID"""

--- a/src/plugins/haruka_bot/plugins/live/live_on.py
+++ b/src/plugins/haruka_bot/plugins/live/live_on.py
@@ -13,7 +13,7 @@ live_on.handle()(permission_check)
 
 live_on.handle()(handle_uid)
 
-live_on.got("uid", prompt="请输入要关注的UID")(uid_check)
+live_on.got("uid", prompt="请输入要开启直播的UID")(uid_check)
 
 
 @live_on.handle()

--- a/src/plugins/haruka_bot/plugins/permission/permission_off.py
+++ b/src/plugins/haruka_bot/plugins/permission/permission_off.py
@@ -1,12 +1,10 @@
-from typing import Union
-
 from nonebot import on_command
-from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageEvent
+from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
 from nonebot.permission import SUPERUSER
 
 from ...database import DB as db
-from ...utils import to_me
+from ...utils import group_only, to_me
 
 permission_off = on_command(
     "关闭权限",
@@ -16,16 +14,12 @@ permission_off = on_command(
 )
 permission_off.__doc__ = """关闭权限"""
 
+permission_off.handle()(group_only)
+
 
 @permission_off.handle()
-async def _(
-    event: Union[PrivateMessageEvent, GroupMessageEvent],
-):
+async def _(event: GroupMessageEvent):
     """关闭当前群权限"""
-
-    if isinstance(event, PrivateMessageEvent):
-        await permission_off.finish("只有群里才能关闭权限")
-        return  # IDE 快乐行
     if await db.set_permission(event.group_id, False):
         await permission_off.finish("已关闭权限，所有人均可操作")
     await permission_off.finish("权限已经关闭了，所有人均可操作")

--- a/src/plugins/haruka_bot/plugins/permission/permission_on.py
+++ b/src/plugins/haruka_bot/plugins/permission/permission_on.py
@@ -1,12 +1,10 @@
-from typing import Union
 from nonebot import on_command
-from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageEvent
-from nonebot.permission import SUPERUSER
+from nonebot.adapters.onebot.v11.event import GroupMessageEvent
 from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
+from nonebot.permission import SUPERUSER
 
 from ...database import DB as db
-from ...utils import to_me
-
+from ...utils import group_only, to_me
 
 permission_on = on_command(
     "开启权限",
@@ -16,14 +14,12 @@ permission_on = on_command(
 )
 permission_on.__doc__ = """开启权限"""
 
+permission_on.handle()(group_only)
+
 
 @permission_on.handle()
-async def _(event: Union[PrivateMessageEvent, GroupMessageEvent]):
+async def _(event: GroupMessageEvent):
     """开启当前群权限"""
-
-    if isinstance(event, PrivateMessageEvent):
-        await permission_on.finish("只有群里才能开启权限")
-        return  # IDE 快乐行
     if await db.set_permission(event.group_id, True):
         await permission_on.finish("已开启权限，只有管理员和主人可以操作")
     await permission_on.finish("权限已经开启了，只有管理员和主人可以操作")

--- a/src/plugins/haruka_bot/plugins/pusher/dynamic_pusher.py
+++ b/src/plugins/haruka_bot/plugins/pusher/dynamic_pusher.py
@@ -1,13 +1,13 @@
 import asyncio
 import traceback
 
-from nonebot.log import logger
+from bilireq.grpc.dynamic import grpc_get_user_dynamics
+from bilireq.grpc.protos.bilibili.app.dynamic.v2.dynamic_pb2 import DynamicType
 from nonebot.adapters.onebot.v11.message import MessageSegment
+from nonebot.log import logger
 
 from ... import config
 from ...database import DB as db
-from bilireq.grpc.dynamic import grpc_get_user_dynamics
-from bilireq.grpc.protos.bilibili.app.dynamic.v2.dynamic_pb2 import DynamicType
 from ...utils import get_dynamic_screenshot, safe_send, scheduler
 
 offset = {}
@@ -18,7 +18,6 @@ offset = {}
 )
 async def dy_sched():
     """动态推送"""
-
     uid = await db.next_uid("dynamic")
     if not uid:
         return

--- a/src/plugins/haruka_bot/plugins/sub/add_sub.py
+++ b/src/plugins/haruka_bot/plugins/sub/add_sub.py
@@ -5,7 +5,14 @@ from nonebot.adapters.onebot.v11.event import MessageEvent
 from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import PROXIES, get_type_id, handle_uid, permission_check, to_me, uid_check
+from ...utils import (
+    PROXIES,
+    get_type_id,
+    handle_uid,
+    permission_check,
+    to_me,
+    uid_check,
+)
 
 add_sub = on_command("关注", aliases={"添加主播"}, rule=to_me(), priority=5)
 add_sub.__doc__ = """关注 UID"""

--- a/src/plugins/haruka_bot/plugins/sub/add_sub.py
+++ b/src/plugins/haruka_bot/plugins/sub/add_sub.py
@@ -2,10 +2,10 @@ from bilireq.exceptions import ResponseCodeError
 from bilireq.user import get_user_info
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import MessageEvent
-from nonebot.typing import T_State
+from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import PROXIES, get_type_id, handle_uid, permission_check, to_me
+from ...utils import PROXIES, get_type_id, handle_uid, permission_check, to_me, uid_check
 
 add_sub = on_command("关注", aliases={"添加主播"}, rule=to_me(), priority=5)
 add_sub.__doc__ = """关注 UID"""
@@ -14,11 +14,12 @@ add_sub.handle()(permission_check)
 
 add_sub.handle()(handle_uid)
 
+add_sub.got("uid", prompt="请输入要关注的UID")(uid_check)
 
-@add_sub.got("uid", prompt="请输入要关注的UID")
-async def _(event: MessageEvent, state: T_State):
+
+@add_sub.handle()
+async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 订阅 UP 主"""
-    uid = state["uid"]
     user = await db.get_user(uid=uid)
     name = user and user.name
     if not name:

--- a/src/plugins/haruka_bot/plugins/sub/delete_sub.py
+++ b/src/plugins/haruka_bot/plugins/sub/delete_sub.py
@@ -1,9 +1,9 @@
 from nonebot import on_command
 from nonebot.adapters.onebot.v11.event import MessageEvent
-from nonebot.typing import T_State
+from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid
+from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
 
 
 delete_sub = on_command("取关", aliases={"删除主播"}, rule=to_me(), priority=5)
@@ -13,11 +13,12 @@ delete_sub.handle()(permission_check)
 
 delete_sub.handle()(handle_uid)
 
+delete_sub.got("uid", prompt="请输入要关注的UID")(uid_check)
 
-@delete_sub.got("uid", prompt="请输入要取关的UID")
-async def _(event: MessageEvent, state: T_State):
+
+@delete_sub.handle()
+async def _(event: MessageEvent, uid: str = ArgPlainText("uid")):
     """根据 UID 删除 UP 主订阅"""
-    uid = state["uid"]
     name = getattr(await db.get_user(uid=uid), "name", None)
     if name:
         result = await db.delete_sub(

--- a/src/plugins/haruka_bot/plugins/sub/delete_sub.py
+++ b/src/plugins/haruka_bot/plugins/sub/delete_sub.py
@@ -13,7 +13,7 @@ delete_sub.handle()(permission_check)
 
 delete_sub.handle()(handle_uid)
 
-delete_sub.got("uid", prompt="请输入要关注的UID")(uid_check)
+delete_sub.got("uid", prompt="请输入要取关的UID")(uid_check)
 
 
 @delete_sub.handle()

--- a/src/plugins/haruka_bot/plugins/sub/delete_sub.py
+++ b/src/plugins/haruka_bot/plugins/sub/delete_sub.py
@@ -3,8 +3,7 @@ from nonebot.adapters.onebot.v11.event import MessageEvent
 from nonebot.params import ArgPlainText
 
 from ...database import DB as db
-from ...utils import get_type_id, permission_check, to_me, handle_uid, uid_check
-
+from ...utils import get_type_id, handle_uid, permission_check, to_me, uid_check
 
 delete_sub = on_command("取关", aliases={"删除主播"}, rule=to_me(), priority=5)
 delete_sub.__doc__ = """取关 UID"""

--- a/src/plugins/haruka_bot/utils/__init__.py
+++ b/src/plugins/haruka_bot/utils/__init__.py
@@ -19,7 +19,7 @@ from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
 from nonebot.exception import FinishedException
 from nonebot.log import logger
 from nonebot.matcher import Matcher
-from nonebot.params import ArgPlainText, CommandArg
+from nonebot.params import ArgPlainText, CommandArg, RawCommand
 from nonebot.permission import SUPERUSER
 from nonebot.rule import Rule
 
@@ -69,6 +69,13 @@ async def permission_check(
     )(bot, event):
         await bot.send(event, "权限不足，目前只有管理员才能使用")
         raise FinishedException
+
+
+async def group_only(
+    matcher: Matcher, event: MessageEvent, command: str = RawCommand()
+):
+    if not isinstance(event, GroupMessageEvent):
+        await matcher.finish(f"只有群里才能{command}")
 
 
 def to_me():

--- a/src/plugins/haruka_bot/utils/__init__.py
+++ b/src/plugins/haruka_bot/utils/__init__.py
@@ -12,11 +12,12 @@ from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageE
 from nonebot.adapters.onebot.v11 import ActionFailed, NetworkError
 from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
 from nonebot.exception import FinishedException
+from nonebot.params import ArgPlainText
 from nonebot.log import logger
 from nonebot.params import CommandArg
 from nonebot.permission import SUPERUSER
 from nonebot.rule import Rule
-from nonebot.typing import T_State
+from nonebot.matcher import Matcher
 
 from .. import config
 
@@ -32,19 +33,20 @@ def get_path(*other):
 
 
 async def handle_uid(
-    bot: Bot,
-    event: MessageEvent,
-    state: T_State,
+    matcher: Matcher,
     command_arg: Message = CommandArg(),
 ):
     uid = command_arg.extract_plain_text().strip()
-    if not uid:
-        return
-    if uid.isdecimal():
-        state["uid"] = uid
-    else:
-        await bot.send(event, "UID 必须为纯数字")
-        raise FinishedException
+    if uid:
+        matcher.set_arg("uid", command_arg)
+
+
+async def uid_check(
+    matcher: Matcher,
+    uid: str = ArgPlainText("uid"),
+):
+    if not uid.isdecimal():
+        await matcher.finish("UID 必须为纯数字")
 
 
 async def permission_check(

--- a/src/plugins/haruka_bot/utils/__init__.py
+++ b/src/plugins/haruka_bot/utils/__init__.py
@@ -7,17 +7,21 @@ import httpx
 import nonebot
 from nonebot import require
 from nonebot.adapters import Bot
-from nonebot.adapters.onebot.v11 import Message, MessageEvent, MessageSegment
+from nonebot.adapters.onebot.v11 import (
+    ActionFailed,
+    Message,
+    MessageEvent,
+    MessageSegment,
+    NetworkError,
+)
 from nonebot.adapters.onebot.v11.event import GroupMessageEvent, PrivateMessageEvent
-from nonebot.adapters.onebot.v11 import ActionFailed, NetworkError
 from nonebot.adapters.onebot.v11.permission import GROUP_ADMIN, GROUP_OWNER
 from nonebot.exception import FinishedException
-from nonebot.params import ArgPlainText
 from nonebot.log import logger
-from nonebot.params import CommandArg
+from nonebot.matcher import Matcher
+from nonebot.params import ArgPlainText, CommandArg
 from nonebot.permission import SUPERUSER
 from nonebot.rule import Rule
-from nonebot.matcher import Matcher
 
 from .. import config
 
@@ -45,8 +49,10 @@ async def uid_check(
     matcher: Matcher,
     uid: str = ArgPlainText("uid"),
 ):
+    uid = uid.strip()
     if not uid.isdecimal():
         await matcher.finish("UID 必须为纯数字")
+    matcher.set_arg("uid", Message(uid))
 
 
 async def permission_check(


### PR DESCRIPTION
## 问题
matcher.got()方法报错，无法正确处理第二条消息发送的UID

## 解决方案
- 使用Arg代替T_State
- 拆分handle_uid为handle_uid和uid_check，用got装饰uid_check

## 预览
![WYL$FKQ BAOGAL ~2GZBI`C](https://user-images.githubusercontent.com/80164656/178334781-9dcef86e-dbaa-4f2b-9ac1-2a80ff85c9c3.png)

