### PR TITLE
📝 更新小小白白话文第二章

### DIFF
--- a/docs/level-0/ch02.md
+++ b/docs/level-0/ch02.md
@@ -4,6 +4,13 @@
 
 考虑到这里涉及到金钱交易比较敏感，本文基于项目的中立立场，本不应该做具体的推荐，但考虑到部分小白第一次接触云服务器，故仅对两个大厂做介绍，并因为以上原因不对挂机宝进行过多的描述（坑太多了）
 
+::: warning 注意
+
+现在阿里云的学生机似乎需要学生认证才能购买，可以去腾讯云，年龄限制为25岁以下
+更新于2023/1/8
+
+:::
+
 第一件事：你需要先确认自身年龄是否在24岁（包含）以下
 
 如果你的年龄~~恰好~~在24岁以下，那么恭喜你，现在两大厂都有学生专享的低价购买/续费活动。
@@ -34,17 +41,17 @@
 
 ::: warning 注意
 
-本文更新于2022/5/27，从此处开始均不可避免的存在时效性，请各位自行鉴别
+本文更新于2023/1/8，从此处开始均不可避免的存在时效性，请各位自行鉴别
 
 :::
 
-1. [python安装包](https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe)（此安装包版本为3.10.4，推荐3.10以上以避免兼容性问题）
+1. [python安装包](https://www.python.org/ftp/python/3.10.9/python-3.10.9-amd64.exe)（此安装包版本为3.10.9，推荐3.10以上以避免兼容性问题）
 2. [VSCode](https://code.visualstudio.com/sha/download?build=stable&os=win32-x64-user)
-3. [go-cqhttp](https://github.com/Mrs4s/go-cqhttp/releases/download/v1.0.0-rc1/go-cqhttp_windows_386.exe)（此客户端版本为v1.0.0-rc1）
+3. [go-cqhttp](https://github.com/Mrs4s/go-cqhttp/releases/latest/download/go-cqhttp_windows_amd64.exe)
 
 ::: details go-cqhttp下载的太慢了/github被墙了没法下载？
 
-​	[go-cqhttp fastgit加速](https://download.fastgit.org/Mrs4s/go-cqhttp/releases/download/v1.0.0-rc1/go-cqhttp_windows_386.exe)
+​	[go-cqhttp fastgit加速](https://download.fastgit.org/Mrs4s/go-cqhttp/releases/latest/download/go-cqhttp_windows_amd64.exe)
 
 :::
 


### PR DESCRIPTION
将go-cqhttp的下载链接指向latest，并切换到amd64版本（因为python和vscode都是x64的
对购买服务器部分添加了时效性警告（或许需要重写相关部分