### PR TITLE
改进下播推送的显示效果

### DIFF
--- a/haruka_bot/plugins/pusher/live_pusher.py
+++ b/haruka_bot/plugins/pusher/live_pusher.py
@@ -57,9 +57,9 @@ async def live_sched():
             if not plugin_config.haruka_live_off_notify:  # 没开下播推送
                 continue
             live_time_msg = (
-                f"\n本次直播时长 {calc_time_total(time.time() - live_time[uid])}。"
+                f"\n本次直播时长 {calc_time_total(time.time() - live_time[uid])}"
                 if live_time.get(uid)
-                else "。"
+                else ""
             )
             live_msg = f"{name} 下播了{live_time_msg}"
 

--- a/haruka_bot/plugins/pusher/live_pusher.py
+++ b/haruka_bot/plugins/pusher/live_pusher.py
@@ -54,7 +54,7 @@ async def live_sched():
             )
         else:  # 下播
             logger.info(f"检测到下播：{name}（{uid}）")
-            if not plugin_config.haruka_live_off_notify:  # 没开下播推送
+            if not plugin_config.haruka_live_off_notify:  # 没关下播推送
                 continue
             live_time_msg = (
                 f"\n本次直播时长 {calc_time_total(time.time() - live_time[uid])}"


### PR DESCRIPTION
1.让下播推送中的直播时长部分在同一行
![IMG_20230716_221518](https://github.com/SK-415/HarukaBot/assets/81549837/13e8bbc5-9874-4293-88b8-400d195e1500)
2.没有直播时长的时候，单独的“XXX 下播了”这一句话后面加句号不美观
![IMG_20230716_224928](https://github.com/SK-415/HarukaBot/assets/81549837/becfd1f0-4df0-497c-a2d2-e9e90dafc9d5)
