### PR TITLE
改进下播推送的显示效果

### DIFF
--- a/haruka_bot/plugins/pusher/live_pusher.py
+++ b/haruka_bot/plugins/pusher/live_pusher.py
@@ -57,9 +57,9 @@ async def live_sched():
             if not plugin_config.haruka_live_off_notify:  # 没开下播推送
                 continue
             live_time_msg = (
-                f"\n本次直播时长 {calc_time_total(time.time() - live_time[uid])}。"
+                f"\n本次直播时长 {calc_time_total(time.time() - live_time[uid])}"
                 if live_time.get(uid)
-                else "。"
+                else ""
             )
             live_msg = f"{name} 下播了{live_time_msg}"
 


### PR DESCRIPTION
让下播推送中的直播时长部分在同一行（去掉直播时长部分句末的句号后，“钟”字就不会在第三行了）
![253810485-13e8bbc5-9874-4293-88b8-400d195e1500](https://github.com/SK-415/HarukaBot/assets/81549837/45a3da3e-e88f-4951-8d84-df134c6d2814)
单独的一句话后面还是不加句号比较美观😘
![253810728-becfd1f0-4df0-497c-a2d2-e9e90dafc9d5](https://github.com/SK-415/HarukaBot/assets/81549837/18c3c978-1408-4ed9-a8f5-d81cb486ea45)
